### PR TITLE
Add syntax page to website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@sentry/cloudflare": "^8.39.0",
 				"@sentry/sveltekit": "^8.38.0",
+				"@sindresorhus/slugify": "^2.2.1",
 				"clipboard-copy": "^4.0.1",
 				"js-toml": "^1.0.0",
 				"svelte-highlight": "^7.7.0"
@@ -2979,6 +2980,61 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/@sindresorhus/slugify": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+			"integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/transliterate": "^1.0.0",
+				"escape-string-regexp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@sindresorhus/slugify/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@sindresorhus/transliterate": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+			"integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"@sentry/cloudflare": "^8.39.0",
 		"@sentry/sveltekit": "^8.38.0",
+		"@sindresorhus/slugify": "^2.2.1",
 		"clipboard-copy": "^4.0.1",
 		"js-toml": "^1.0.0",
 		"svelte-highlight": "^7.7.0"

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -20,6 +20,7 @@
 			<div class="flex gap-3 flex-wrap">
 				<a href="/" class={currentPage('/')}>Home</a>
 				<a href="/about" class={currentPage('/about')}>What is carbon.txt?</a>
+				<a href="/syntax" class={currentPage('/syntax')}>Syntax</a>
 				<a href="/how/digital-services" class={currentPage('/how/digital-services')}>Get started</a>
 				<a href="/tools" class={currentPage('/tools')}>Tools</a>
 				<a href="/faq" class={currentPage('/faq')}>FAQ</a>

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -157,13 +157,6 @@
 {:else if type === 'org'}
 	<div class="org-input">
 		<!-- A text input with validation to check that it is a domain -->
-		<div class="form-group">
-			<label for="domain">Domain</label>
-			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
-			{#if error.field === 'org-domain'}
-				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
-			{/if}
-		</div>
 		<!-- A select listing some online services -->
 		<div class="form-group">
 			<label for="doctype">Document type</label>
@@ -181,6 +174,13 @@
 			<label for="url">URL</label>
 			<input type="text" name="url" bind:value={newObject.url} placeholder="https://example.com/our-sustainability-page" />
 			{#if error.field === 'org-url'}
+				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
+			{/if}
+		</div>
+		<div class="form-group">
+			<label for="domain">Domain</label>
+			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
+			{#if error.field === 'org-domain'}
 				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
 			{/if}
 		</div>

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -4,6 +4,7 @@
 	import services from '$lib/utils/upstreamServices'
 	import fetchEvidenceTypes from '$lib/utils/evidenceTypes'
 	import { onMount } from 'svelte'
+	import slugify from '@sindresorhus/slugify'
 
 	let evidenceTypes = []
 	onMount(async () => {
@@ -17,9 +18,9 @@
 
 	if (type === 'org') {
 		newObject = {
-			domain: '',
 			doctype: '',
-			url: ''
+			url: '',
+			domain: ''
 		}
 	}
 
@@ -106,9 +107,9 @@
 				return org
 			})
 			newObject = {
-				domain: '',
 				doctype: '',
-				url: ''
+				url: '',
+				domain: ''
 			}
 			return
 		}
@@ -119,7 +120,10 @@
 		}
 
 		store.update((upstream) => {
-			upstream.push(newObject)
+			upstream.push({
+				domain: newObject.domain,
+				service: slugify(newObject.service)
+			})
 			return upstream
 		})
 		newObject = {
@@ -134,7 +138,10 @@
 	<!-- A label for the domain & services inputs -->
 	<div class="upstream-input">
 		<div class="form-group">
-			<label for="domain">Domain</label>
+			<span>
+				<label for="domain">Domain</label>
+				<small>The domain of the provider who's services you use.</small>
+			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'upstream-domain'}
 				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
@@ -142,12 +149,16 @@
 		</div>
 		<!-- A select listing some online services -->
 		<div class="form-group">
-			<label for="service">Service</label>
-			<select name="service" bind:value={newObject.service}>
+			<span>
+				<label for="service">Service</label>
+				<small>A short name for the service provided.</small>
+			</span>
+			<input type="text" name="service" bind:value={newObject.service} placeholder="hosting-provider" />
+			<!-- <select name="service" bind:value={newObject.service}>
 				{#each services as service}
 					<option value={service.slug}>{service.name}</option>
 				{/each}
-			</select>
+			</select> -->
 			{#if error.field === 'upstream-service'}
 				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
 			{/if}
@@ -159,7 +170,10 @@
 		<!-- A text input with validation to check that it is a domain -->
 		<!-- A select listing some online services -->
 		<div class="form-group">
-			<label for="doctype">Document type</label>
+			<span>
+				<label for="doctype">Document type</label>
+				<small>The type of document that is being linked to.</small>
+			</span>
 			<select name="doctype" bind:value={newObject.doctype}>
 				{#each evidenceTypes as doctype}
 					<option value={doctype.slug}>{doctype.name}</option>
@@ -171,14 +185,20 @@
 		</div>
 		<!-- A text input with validation to check that it is a URL -->
 		<div class="form-group">
-			<label for="url">URL</label>
+			<span>
+				<label for="url">URL</label>
+				<small>The publicly accessible URL for the document.</small>
+			</span>
 			<input type="text" name="url" bind:value={newObject.url} placeholder="https://example.com/our-sustainability-page" />
 			{#if error.field === 'org-url'}
 				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
 			{/if}
 		</div>
 		<div class="form-group">
-			<label for="domain">Domain</label>
+			<span>
+				<label for="domain">Domain</label>
+				<small>The domain for which the document applies.</small>
+			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'org-domain'}
 				<div class="p-2 border rounded alert__error mt-1"><small>{error.message}</small></div>
@@ -192,6 +212,11 @@
 	.form-group {
 		display: flex;
 		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.form-group small {
+		display: block;
 	}
 
 	.upstream-input,

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -150,7 +150,7 @@
 		<!-- A select listing some online services -->
 		<div class="form-group">
 			<span>
-				<label for="service">Service</label>
+				<label for="service">Service type</label>
 				<small>A short name for the service provided.</small>
 			</span>
 			<input type="text" name="service" bind:value={newObject.service} placeholder="hosting-provider" />

--- a/src/lib/components/tools/BuilderOutput.svelte
+++ b/src/lib/components/tools/BuilderOutput.svelte
@@ -1,5 +1,4 @@
 <script>
-	import upstreamServices from '$lib/utils/upstreamServices'
 	import fetchEvidenceTypes from '$lib/utils/evidenceTypes'
 	import { evidenceTypes } from '$lib/store'
 	import { onMount } from 'svelte'
@@ -14,10 +13,6 @@
 
 	const removeUpstream = (provider) => {
 		store.update((upstream) => upstream.filter((item) => item !== provider))
-	}
-
-	const serviceName = (service) => {
-		return upstreamServices.find((item) => item.slug === service).name
 	}
 
 	const evidenceName = (evidence) => {
@@ -37,7 +32,7 @@
 			{/if}
 			<li class="grid grid-cols-3 gap-2 items-center p-2 odd:bg-green-100 even:bg-gray-100">
 				<div class="domain">{provider.domain}</div>
-				<div class="service">{serviceName(provider.service)}</div>
+				<div class="service">{provider.service}</div>
 				<button on:click={() => removeUpstream(provider)} aria-label="Remove"
 					><svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/tools/BuilderOutput.svelte
+++ b/src/lib/components/tools/BuilderOutput.svelte
@@ -27,7 +27,7 @@
 			{#if index === 0}
 				<li class="grid grid-cols-3 gap-2 items-center p-2 bg-green-600 text-white">
 					<span class="domain">Domain</span>
-					<span class="service">Service</span>
+					<span class="service">Service type</span>
 				</li>
 			{/if}
 			<li class="grid grid-cols-3 gap-2 items-center p-2 odd:bg-green-100 even:bg-gray-100">

--- a/src/lib/components/tools/BuilderOutput.svelte
+++ b/src/lib/components/tools/BuilderOutput.svelte
@@ -59,9 +59,9 @@
 			</li>
 		{:else if Object.keys(provider).length === 3}
 			<li class="grid grid-cols-4 gap-2 items-center p-2 odd:bg-green-100 even:bg-gray-100">
-				<div class="domain"><span>{provider.domain}</span></div>
 				<div class="doctype"><span>{evidenceName(provider.doctype)}</span></div>
 				<div class="url"><span>{provider.url}</span></div>
+				<div class="domain"><span>{provider.domain}</span></div>
 				<button on:click={() => removeUpstream(provider)} aria-label="Remove"
 					><svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/tools/DomainHash.svelte
+++ b/src/lib/components/tools/DomainHash.svelte
@@ -4,7 +4,7 @@
 
 <form class="form" action="?/domainHash" method="POST" use:enhance>
 	<fieldset class="border pl-4 pr-4 pb-4 rounded-md mb-[1rem]">
-		<legend class="text-2xl pl-2 pr-2">Green Web Foundation credentials:</legend>
+		<legend class="text-2xl pl-2 pr-2">Green Web Foundation login details:</legend>
 		<div class="flex flex-col gap-1">
 			<label for="carbon-txt-url">Username</label>
 			<div class="flex gap-3 flex-wrap">

--- a/src/lib/components/tools/SyntaxValidatorSuccess.svelte
+++ b/src/lib/components/tools/SyntaxValidatorSuccess.svelte
@@ -34,12 +34,12 @@
 			<Heading level={2}>File contents</Heading>
 			<p>The content found in the carbon.txt file is displayed below:</p>
 
-			{#if form?.response.data.upstream && form?.response.data.upstream.providers.length > 0}
+			{#if form?.response.data.upstream && form?.response.data.upstream.services?.length > 0}
 				<div class="relative overflow-x-auto">
 					<table class="w-full">
 						<thead>
 							<tr>
-								<td colspan="2">Upstream providers</td>
+								<td colspan="2">Upstream services</td>
 							</tr>
 							<tr>
 								<th>Domain</th>
@@ -47,7 +47,7 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each form?.response.data.upstream.providers as { domain, service }}
+							{#each form?.response.data.upstream.services as { domain, service }}
 								<tr>
 									<td class="whitespace-nowrap">{domain}</td>
 									<td class="whitespace-nowrap">{service}</td>
@@ -58,12 +58,12 @@
 				</div>
 			{/if}
 
-			{#if form?.response.data.org && form?.response.data.org.credentials.length > 0}
+			{#if form?.response.data.org && form?.response.data.org.disclosures.length > 0}
 				<div class="relative overflow-x-auto">
 					<table class="w-full">
 						<thead>
 							<tr>
-								<td colspan="3">Organisation credentials</td>
+								<td colspan="3">Organisation disclosures</td>
 							</tr>
 							<tr>
 								<th>Domain</th>
@@ -72,10 +72,10 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each form?.response.data.org.credentials as { domain, doctype, url }}
+							{#each form?.response.data.org.disclosures as { domain, doc_type, url }}
 								<tr>
 									<td class="whitespace-nowrap">{domain}</td>
-									<td class="whitespace-nowrap">{doctype}</td>
+									<td class="whitespace-nowrap">{doc_type}</td>
 									<td class="whitespace-nowrap">{url}</td>
 								</tr>
 							{/each}

--- a/src/lib/utils/evidenceTypes.js
+++ b/src/lib/utils/evidenceTypes.js
@@ -2,10 +2,14 @@ const fetchEvidenceTypes = async () => {
     const schema = await fetch('https://carbon-txt-api.greenweb.org/api/json_schema/')
     const json = await schema.json()
 
-    return json.$defs.Credential.properties.doctype.enum.map((type) => {
+    return json.$defs.Disclosure.properties.doc_type.enum.map((type) => {
+        let name = type.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+        if (name.startsWith('Csrd')) {
+            name = name.replace('Csrd', 'CSRD')
+        }
         return {
             // Make the name a human-readable string with spaces and capitalization
-            name: type.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+            name: name,
             slug: type
         }
     })

--- a/src/lib/utils/exampleToml.js
+++ b/src/lib/utils/exampleToml.js
@@ -1,13 +1,10 @@
 export const digitalServiceToml = `[org]
-# Optional.
-# An array of documents that point to evidence of green claims made by mycompany.com.
 disclosures = [
 	{ doc_type = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
 	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
 ]
 	
 [upstream]	
-# An array of providers mycompany.com is using to deliver our service
 services = [
 	{ domain = "cloud.google.com", service_type = "shared-hosting" },
 	{ domain = "aws.amazon.com", service_type = "cdn" }

--- a/src/lib/utils/exampleToml.js
+++ b/src/lib/utils/exampleToml.js
@@ -1,14 +1,14 @@
-export const digitalServiceToml = `[upstream]	
-# An array of providers mycompany.com is using to deliver our service
-providers = [
-	{ domain = "cloud.google.com", service = "shared-hosting" },
-	{ domain = "aws.amazon.com", service = "cdn" }
-]
-
-[org]
+export const digitalServiceToml = `[org]
 # Optional.
 # An array of documents that point to evidence of green claims made by mycompany.com.
 credentials = [
 	{ domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
 	{ domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
+]
+	
+[upstream]	
+# An array of providers mycompany.com is using to deliver our service
+services = [
+	{ domain = "cloud.google.com", service-type = "shared-hosting" },
+	{ domain = "aws.amazon.com", service-type = "cdn" }
 ]`

--- a/src/lib/utils/exampleToml.js
+++ b/src/lib/utils/exampleToml.js
@@ -1,14 +1,14 @@
 export const digitalServiceToml = `[org]
 # Optional.
 # An array of documents that point to evidence of green claims made by mycompany.com.
-credentials = [
-	{ doctype = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
-	{ doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
+disclosures = [
+	{ doc_type = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
+	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
 ]
 	
 [upstream]	
 # An array of providers mycompany.com is using to deliver our service
 services = [
-	{ domain = "cloud.google.com", service-type = "shared-hosting" },
-	{ domain = "aws.amazon.com", service-type = "cdn" }
+	{ domain = "cloud.google.com", service_type = "shared-hosting" },
+	{ domain = "aws.amazon.com", service_type = "cdn" }
 ]`

--- a/src/lib/utils/exampleToml.js
+++ b/src/lib/utils/exampleToml.js
@@ -2,8 +2,8 @@ export const digitalServiceToml = `[org]
 # Optional.
 # An array of documents that point to evidence of green claims made by mycompany.com.
 credentials = [
-	{ domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
-	{ domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
+	{ doctype = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
+	{ doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
 ]
 	
 [upstream]	

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -1,0 +1,113 @@
+import { properties } from "svelte-highlight/languages";
+
+export const syntaxVersions = [
+    {
+        name: '0.1',
+        current: false,
+        validFrom: '2021-01-01',
+        validTo: '2025-01-22',
+        syntax: [
+            {
+                name: 'upstream',
+                required: true,
+                longTitle: 'Upstream providers',
+                description: 'Information linking your organisation to upstream providers used to deliver your services.',
+                properties: [
+                    {
+                        name: 'providers',
+                        parent: 'upstream',
+                        required: true,
+                        longTitle: 'Providers',
+                        description: 'Information linking your organisation to upstream providers used to deliver your services.',
+                        type: 'array',
+                        properties: [
+                            {
+                                name: 'domain',
+                                required: true,
+                                parent: 'providers',
+                                longTitle: 'Domain',
+                                description: 'The domain of the organisation providing the upstream service.',
+                                type: 'string',
+                            },
+                            {
+                                name: 'service',
+                                required: true,
+                                parent: 'providers',
+                                longTitle: 'Service',
+                                description: 'A slug representing the service provided by the upstream provider.',
+                                type: 'string',
+                            }
+                        ]
+                    }
+                ],
+                example: `[upstream]
+providers = [
+    { domain = "cloud.google.com", service = "shared-hosting" },
+    { domain = "aws.amazon.com", service = "cdn" }
+]`
+            },
+                {
+                    name: 'org',
+                    required: false,
+                    longTitle: 'Organisation credentials',
+                    description: 'Links to documents that show your organisations sustainability credentials.',
+                    properties: [
+                        {
+                            name: 'credentials',
+                            parent: 'org',
+                            required: false,
+                            longTitle: 'Credentials',
+                            description: 'Links to documents that show your organisations sustainability credentials.',
+                            type: 'array',
+                            properties: [
+                                {
+                                    name: 'domain',
+                                    required: false,
+                                    parent: 'credentials',
+                                    longTitle: 'Domain',
+                                    description: 'The domain of your organisation.',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'doctype',
+                                    required: false,
+                                    parent: 'credentials',
+                                    longTitle: 'Document type',
+                                    description: 'A slugified string representing the type of document you are linking to.',
+                                    type: 'string',
+                                },
+                                {
+                                    name: 'url',
+                                    required: false,
+                                    parent: 'credentials',
+                                    longTitle: 'URL',
+                                    description: 'The URL of the document you are linking to.',
+                                    type: 'url',
+                                }
+                            ]
+                        }
+                    ],
+                    example: `[org]
+credentials = [
+    { domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
+    { domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
+]`,
+                },
+            ],
+        example: `[upstream]	
+providers = [
+    { domain = "cloud.google.com", service = "shared-hosting" },
+    { domain = "aws.amazon.com", service = "cdn" }
+]
+
+[org]
+credentials = [
+    { domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
+    { domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
+]`
+    },
+    // {
+    //     name: '0.2',
+    //     current: true,
+    // }
+]

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -10,6 +10,7 @@ export const syntaxVersions = [
             {
                 name: 'upstream',
                 required: true,
+                type: '[table]',
                 longTitle: 'Upstream providers',
                 description: 'Information linking your organisation to upstream providers used to deliver your services.',
                 properties: [
@@ -17,6 +18,7 @@ export const syntaxVersions = [
                         name: 'providers',
                         parent: 'upstream',
                         required: true,
+                        type: '[[array]]',
                         longTitle: 'Providers',
                         description: 'Information linking your organisation to upstream providers used to deliver your services.',
                         type: 'array',
@@ -49,6 +51,7 @@ providers = [
                 {
                     name: 'org',
                     required: false,
+                    type: '[table]',
                     longTitle: 'Organisation credentials',
                     description: 'Links to documents that show your organisations sustainability credentials.',
                     properties: [
@@ -56,6 +59,7 @@ providers = [
                             name: 'credentials',
                             parent: 'org',
                             required: false,
+                            type: '[[array]]',
                             longTitle: 'Credentials',
                             description: 'Links to documents that show your organisations sustainability credentials.',
                             type: 'array',
@@ -106,8 +110,112 @@ credentials = [
     { domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
 ]`
     },
-    // {
-    //     name: '0.2',
-    //     current: true,
-    // }
+    {
+        name: '0.2',
+        current: true,
+        validFrom: '2025-01-23',
+        validTo: '-',
+        syntax: [
+            {
+                name: 'org',
+                required: true,
+                longTitle: 'Organisation disclosures',
+                // description: 'Links to documents that show your organisations sustainability disclosures.',
+                type: '[table]',
+                properties: [
+                    {
+                        name: 'disclosures',
+                        parent: 'org',
+                        required: false,
+                        longTitle: 'disclosures',
+                        description: 'Links to documents that show your organisations sustainability data disclosures.',
+                        type: '[[array]]',
+                        properties: [
+                            {
+                                name: 'doc_type',
+                                required: true,
+                                parent: 'disclosures',
+                                longTitle: 'Document type',
+                                description: 'A slugified string representing the type of document you are linking to.',
+                                type: 'string',
+                            },
+                            {
+                                name: 'url',
+                                required: true,
+                                parent: 'disclosures',
+                                longTitle: 'URL',
+                                description: 'The URL of the document you are linking to.',
+                                type: 'url',
+                            },
+                            {
+                                name: 'domain',
+                                required: false,
+                                parent: 'disclosures',
+                                longTitle: 'Domain',
+                                description: 'The domain for which the disclosure applies.',
+                                type: 'string',
+                            },
+                        ]
+                    }
+                ],
+                example: `[org]
+disclosures = [
+	{ doc_type = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
+	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
+]`,
+            },
+            {
+                name: 'upstream',
+                required: true,
+                type: '[table]',
+                longTitle: 'Upstream services',
+                // description: 'Information linking your organisation to upstream providers used to deliver your services.',
+                properties: [
+                    {
+                        name: 'services',
+                        parent: 'upstream',
+                        required: false,
+                        longTitle: 'Services',
+                        description: 'Information linking your organisation to upstream providers you use.',
+                        type: '[[array]]',
+                        properties: [
+                            {
+                                name: 'domain',
+                                required: false,
+                                parent: 'services',
+                                longTitle: 'Domain',
+                                description: 'The domain of the organisation providing the upstream service.',
+                                type: 'string',
+                            },
+                            {
+                                name: 'service_type',
+                                required: false,
+                                parent: 'services',
+                                longTitle: 'Service type',
+                                description: 'A slug representing the service provided by the upstream provider.',
+                                type: 'string',
+                            }
+                        ]
+                    }
+                ],
+                example: `[upstream]
+services = [
+    { domain = "cloud.google.com", service_type = "shared-hosting" },
+    { domain = "aws.amazon.com", service_type = "cdn" }
+]`
+            },
+                
+            ],
+        example: `[org]
+disclosures = [
+	{ doc_type = "webpage", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
+	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
+]
+	
+[upstream]	
+services = [
+	{ domain = "cloud.google.com", service_type = "shared-hosting" },
+	{ domain = "aws.amazon.com", service_type = "cdn" }
+]`
+    },
 ]

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -6,6 +6,7 @@ export const syntaxVersions = [
         current: false,
         validFrom: '2021-01-01',
         validTo: '2025-01-22',
+        language: 'TOML',
         syntax: [
             {
                 name: 'upstream',
@@ -115,6 +116,7 @@ credentials = [
         current: true,
         validFrom: '2025-01-23',
         validTo: '-',
+        language: 'TOML',
         syntax: [
             {
                 name: 'org',

--- a/src/routes/syntax/+page.svelte
+++ b/src/routes/syntax/+page.svelte
@@ -43,6 +43,7 @@
 			<thead>
 				<tr>
 					<th>Latest version</th>
+					<th>Language</th>
 					<th>Valid from</th>
 					<th>Valid to</th>
 				</tr>
@@ -50,6 +51,7 @@
 			<tbody>
 				<tr>
 					<td>{currentSyntax.current}</td>
+					<td>{currentSyntax.language}</td>
 					<td>{currentSyntax.validFrom}</td>
 					<td>{currentSyntax.validTo}</td>
 				</tr>

--- a/src/routes/syntax/+page.svelte
+++ b/src/routes/syntax/+page.svelte
@@ -1,0 +1,158 @@
+<script>
+	// Components
+	import Code from '$lib/components/Code.svelte'
+	import Heading from '$lib/components/Heading.svelte'
+	import Button from '$lib/components/Button.svelte'
+	import What from '$lib/components/content/What.svelte'
+	import Goals from '$lib/components/content/Goals.svelte'
+	import Why from '$lib/components/content/Why.svelte'
+	import Callout from '$lib/components/Callout.svelte'
+	import TGWF_Bolt from '$lib/svg/tgwf_logo_bolt.svelte'
+	import Pilot from '$lib/components/Pilot.svelte'
+
+	import { syntaxVersions } from '$lib/utils/syntax.js'
+	import { properties } from 'svelte-highlight/languages'
+
+	let currentSyntax = syntaxVersions.filter((version) => version.current)[0] || syntaxVersions[0]
+	let selectedSyntax = currentSyntax.name
+
+	console.log(currentSyntax)
+</script>
+
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+	<div class="w-100 mb-[1rem] pt-[2.5rem]">
+		<Heading level={1}>Carbon.txt syntax</Heading>
+		<div class="flex flex-auto gap-10 items-center" aria-live="polite">This page specifies the current v{currentSyntax.name} syntax for carbon.txt files.</div>
+
+		<div class="mt-8">
+			Viewing syntax for <select bind:value={selectedSyntax} class="my-2" on:change={() => (currentSyntax = syntaxVersions.filter((version) => version.name === selectedSyntax)[0])}>
+				{#each syntaxVersions as version}
+					<option value={version.name}>{version.name}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+	{#if !currentSyntax.current}
+		<div class="border-2 border-dark-gray alert__warning text-center p-4">
+			<p class="text-sm sm:text-base">You are viewing content for an older version of the carbon.txt syntax.</p>
+		</div>
+	{/if}
+</section>
+
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+	<Heading level={2}>Carbon.txt v{currentSyntax.name}</Heading>
+	<div class="relative overflow-x-auto mb-4">
+		<table class="w-full">
+			<thead>
+				<tr>
+					<th>Latest version</th>
+					<th>Valid from</th>
+					<th>Valid to</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>{currentSyntax.current}</td>
+					<td>{currentSyntax.validFrom}</td>
+					<td>{currentSyntax.validTo}</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<div class="w-100 mb-[5rem] grid grid-cols-1 gap-10"></div>
+</section>
+
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+	<div class="w-100 mb-[5rem] grid grid-cols-1 gap-10">
+		<Heading level={2}>Syntax</Heading>
+
+		<div class="relative overflow-x-auto">
+			{#each currentSyntax.syntax as block}
+				<table class="w-full">
+					<thead>
+						<tr>
+							<th>Property</th>
+							<th>Parent</th>
+							<th>Required</th>
+							<th>description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{block.name}</td>
+							<td></td>
+							<td>{block.required}</td>
+							<td>{block.description}</td>
+						</tr>
+						{#if block.properties}
+							{#each block.properties as property}
+								<tr>
+									<td>↳ {property.name}</td>
+									<td>{property.parent}</td>
+									<td>{property.required}</td>
+									<td>{property.description}</td>
+								</tr>
+								{#if property.properties}
+									{#each property.properties as subProperty}
+										<tr>
+											<td>&nbsp; &nbsp;↳ {subProperty.name}</td>
+											<td>{subProperty.parent}</td>
+											<td>{subProperty.required}</td>
+											<td>{subProperty.description}</td>
+										</tr>
+									{/each}
+								{/if}
+							{/each}
+						{/if}
+						{#if block.example}
+							<tr>
+								<td colspan="4">
+									<Code code={block.example} />
+								</td>
+							</tr>
+						{/if}
+					</tbody>
+				</table>
+			{/each}
+		</div>
+	</div>
+</section>
+
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+	<div class="w-100 mb-[5rem] grid grid-cols-1 gap-10">
+		<Heading level={2}>Code sample</Heading>
+		<Code code={syntaxVersions.filter((version) => version.name === currentSyntax.name)[0]?.example} />
+	</div>
+</section>
+
+<style>
+	select {
+		display: inline-block;
+		width: max-content;
+	}
+
+	table {
+		border-radius: 5px;
+	}
+
+	thead > tr + tr {
+		@apply bg-purple-100;
+		/* @apply border-b border-purple-400; */
+	}
+
+	thead {
+		font-weight: bold;
+		text-align: left;
+	}
+
+	thead > tr:first-of-type {
+		@apply bg-purple-800;
+		@apply text-white;
+	}
+
+	th,
+	td {
+		@apply px-4 py-4;
+		@apply border-b border-purple-400;
+	}
+</style>

--- a/src/routes/syntax/+page.svelte
+++ b/src/routes/syntax/+page.svelte
@@ -11,12 +11,9 @@
 	import Pilot from '$lib/components/Pilot.svelte'
 
 	import { syntaxVersions } from '$lib/utils/syntax.js'
-	import { properties } from 'svelte-highlight/languages'
 
 	let currentSyntax = syntaxVersions.filter((version) => version.current)[0] || syntaxVersions[0]
 	let selectedSyntax = currentSyntax.name
-
-	console.log(currentSyntax)
 </script>
 
 <section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
@@ -33,13 +30,13 @@
 		</div>
 	</div>
 	{#if !currentSyntax.current}
-		<div class="border-2 border-dark-gray alert__warning text-center p-4">
+		<div class="border-2 border-dark-gray alert__warning text-center p-4" aria-live="polite">
 			<p class="text-sm sm:text-base">You are viewing content for an older version of the carbon.txt syntax.</p>
 		</div>
 	{/if}
 </section>
 
-<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4" aria-live="polite">
 	<Heading level={2}>Carbon.txt v{currentSyntax.name}</Heading>
 	<div class="relative overflow-x-auto mb-4">
 		<table class="w-full">
@@ -62,43 +59,47 @@
 	<div class="w-100 mb-[5rem] grid grid-cols-1 gap-10"></div>
 </section>
 
-<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4">
+<section class="container mx-auto pt-6 md:pt-8 px-2 sm:px-4" aria-live="polite">
 	<div class="w-100 mb-[5rem] grid grid-cols-1 gap-10">
 		<Heading level={2}>Syntax</Heading>
 
-		<div class="relative overflow-x-auto">
-			{#each currentSyntax.syntax as block}
+		{#each currentSyntax.syntax as block}
+			<div class="relative overflow-x-auto">
 				<table class="w-full">
 					<thead>
 						<tr>
 							<th>Property</th>
 							<th>Parent</th>
+							<th>Type</th>
 							<th>Required</th>
-							<th>description</th>
+							<th>Description</th>
 						</tr>
 					</thead>
 					<tbody>
 						<tr>
 							<td>{block.name}</td>
 							<td></td>
+							<td>{block.type}</td>
 							<td>{block.required}</td>
-							<td>{block.description}</td>
+							<td class="prose text-wrap max-w-prose">{block.description}</td>
 						</tr>
 						{#if block.properties}
 							{#each block.properties as property}
 								<tr>
 									<td>↳ {property.name}</td>
 									<td>{property.parent}</td>
+									<td>{property.type}</td>
 									<td>{property.required}</td>
-									<td>{property.description}</td>
+									<td class="prose text-wrap max-w-prose">{property.description}</td>
 								</tr>
 								{#if property.properties}
 									{#each property.properties as subProperty}
 										<tr>
 											<td>&nbsp; &nbsp;↳ {subProperty.name}</td>
 											<td>{subProperty.parent}</td>
+											<td>{subProperty.type}</td>
 											<td>{subProperty.required}</td>
-											<td>{subProperty.description}</td>
+											<td class="prose text-wrap max-w-prose">{subProperty.description}</td>
 										</tr>
 									{/each}
 								{/if}
@@ -106,15 +107,15 @@
 						{/if}
 						{#if block.example}
 							<tr>
-								<td colspan="4">
+								<td colspan="5">
 									<Code code={block.example} />
 								</td>
 							</tr>
 						{/if}
 					</tbody>
 				</table>
-			{/each}
-		</div>
+			</div>
+		{/each}
 	</div>
 </section>
 

--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -15,13 +15,13 @@
 	let copyText = 'Copy'
 
 	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service='${provider.service}' }`).join(',\n    ')
-	const mapOrg = () => $builderOrg.map((credential) => `{ domain='${credential.domain}', doctype='${credential.doctype}', url='${credential.url}' }`).join(',\n    ')
+	const mapOrg = () => $builderOrg.map((credential) => `{ doctype='${credential.doctype}', url='${credential.url}', domain='${credential.domain}' }`).join(',\n    ')
 
 	$: outputCode = `[org]
-credentials = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]
+disclosures = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]
 
 [upstream]
-providers = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}]`
+services = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}]`
 
 	const resetBuilder = () => {
 		builderUpstream.set([])

--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -14,7 +14,7 @@
 
 	let copyText = 'Copy'
 
-	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service='${provider.service}' }`).join(',\n    ')
+	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service-type='${provider.service}' }`).join(',\n    ')
 	const mapOrg = () => $builderOrg.map((credential) => `{ doctype='${credential.doctype}', url='${credential.url}', domain='${credential.domain}' }`).join(',\n    ')
 
 	$: outputCode = `[org]

--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -17,11 +17,11 @@
 	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service='${provider.service}' }`).join(',\n    ')
 	const mapOrg = () => $builderOrg.map((credential) => `{ domain='${credential.domain}', doctype='${credential.doctype}', url='${credential.url}' }`).join(',\n    ')
 
-	$: outputCode = `[upstream]
-providers = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}]
+	$: outputCode = `[org]
+credentials = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]
 
-[org]
-credentials = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]`
+[upstream]
+providers = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}]`
 
 	const resetBuilder = () => {
 		builderUpstream.set([])
@@ -39,18 +39,21 @@ credentials = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]`
 				<p>Use this builder to create a carbon.txt file for your organisation.</p>
 			</div>
 			<div class="py-8">
+				<div>
+					<Heading level={2}>Required</Heading>
+					<Heading level={3}>Organisational disclosures</Heading>
+					<p class="mb-10">List the documents that show evidence of your green claims, such as CSRD, EED, ESG and/or other sustainability reporting.</p>
+					<BuilderInput store={builderOrg} type="org" />
+					<BuilderOutput store={builderOrg} />
+				</div>
+				<hr />
 				<div class="mb-[3rem]">
-					<Heading level={2}>Upstream providers</Heading>
-					<p class="mb-10">List the providers you use to deliver your service</p>
+					<Heading level={2}>Optional</Heading>
+					<Heading level={3}>Upstream services</Heading>
+					<p class="mb-10">List the services providers you use to deliver your service.</p>
 					<BuilderInput store={builderUpstream} />
 					<p>Can't find a service you need in the list? <a href="https://github.com/thegreenwebfoundation/carbon.txt/issues/16">Let us know</a>.</p>
 					<BuilderOutput store={builderUpstream} />
-				</div>
-				<div>
-					<Heading level={2}>Your organisation's data</Heading>
-					<p class="mb-10">List the documents that show evidence of your green claims</p>
-					<BuilderInput store={builderOrg} type="org" />
-					<BuilderOutput store={builderOrg} />
 				</div>
 			</div>
 		</div>
@@ -75,3 +78,9 @@ credentials = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]`
 </section>
 
 <ToolsNav currentView="builder" />
+
+<style>
+	hr {
+		margin-block: 2rem;
+	}
+</style>

--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -14,8 +14,8 @@
 
 	let copyText = 'Copy'
 
-	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service-type='${provider.service}' }`).join(',\n    ')
-	const mapOrg = () => $builderOrg.map((credential) => `{ doctype='${credential.doctype}', url='${credential.url}', domain='${credential.domain}' }`).join(',\n    ')
+	const mapUpstream = () => $builderUpstream.map((provider) => `{ domain='${provider.domain}', service_type='${provider.service}' }`).join(',\n    ')
+	const mapOrg = () => $builderOrg.map((credential) => `{ doc_type='${credential.doctype}', url='${credential.url}', domain='${credential.domain}' }`).join(',\n    ')
 
 	$: outputCode = `[org]
 disclosures = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]
@@ -52,7 +52,6 @@ services = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}
 					<Heading level={3}>Upstream services</Heading>
 					<p class="mb-10">List the services providers you use to deliver your service.</p>
 					<BuilderInput store={builderUpstream} />
-					<p>Can't find a service you need in the list? <a href="https://github.com/thegreenwebfoundation/carbon.txt/issues/16">Let us know</a>.</p>
 					<BuilderOutput store={builderUpstream} />
 				</div>
 			</div>

--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -37,6 +37,12 @@ services = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}
 			<div class="prose md:w-[80%] mb-[3rem]">
 				<Heading level={1}>Builder</Heading>
 				<p>Use this builder to create a carbon.txt file for your organisation.</p>
+				<Callout>
+					<p>
+						This builder uses <b>version 0.2 syntax</b> of the carbon.txt syntax.
+					</p>
+					<div class="w-max mx-auto mt-[2rem]"><Button link="/syntax">Learn more about the syntax</Button></div>
+				</Callout>
 			</div>
 			<div class="py-8">
 				<div>

--- a/src/routes/tools/checker/+page.svelte
+++ b/src/routes/tools/checker/+page.svelte
@@ -47,12 +47,12 @@
 			<Heading level={2}>File contents</Heading>
 			<p>The content found in the carbon.txt file is displayed below:</p>
 
-			{#if form?.response.data.upstream && form?.response.data.upstream.providers.length > 0}
+			{#if form?.response.data.upstream && form?.response.data.upstream.services.length > 0}
 				<div class="relative overflow-x-auto">
 					<table class="w-full">
 						<thead>
 							<tr>
-								<td colspan="2">Upstream providers</td>
+								<td colspan="2">Upstream services</td>
 							</tr>
 							<tr>
 								<th>Domain</th>
@@ -60,7 +60,7 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each form?.response.data.upstream.providers as { domain, service }}
+							{#each form?.response.data.upstream.services as { domain, service }}
 								<tr>
 									<td class="whitespace-nowrap">{domain}</td>
 									<td class="whitespace-nowrap">{service}</td>
@@ -71,12 +71,12 @@
 				</div>
 			{/if}
 
-			{#if form?.response.data.org && form?.response.data.org.credentials.length > 0}
+			{#if form?.response.data.org && form?.response.data.org.disclosures.length > 0}
 				<div class="relative overflow-x-auto">
 					<table class="w-full">
 						<thead>
 							<tr>
-								<td colspan="3">Organisation credentials</td>
+								<td colspan="3">Organisation disclosures</td>
 							</tr>
 							<tr>
 								<th>Domain</th>
@@ -85,10 +85,10 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each form?.response.data.org.credentials as { domain, doctype, url }}
+							{#each form?.response.data.org.disclosures as { domain, doc_type, url }}
 								<tr>
 									<td class="whitespace-nowrap">{domain}</td>
-									<td class="whitespace-nowrap">{doctype}</td>
+									<td class="whitespace-nowrap">{doc_type}</td>
 									<td class="whitespace-nowrap">{url}</td>
 								</tr>
 							{/each}

--- a/src/routes/tools/validator/+page.server.js
+++ b/src/routes/tools/validator/+page.server.js
@@ -88,7 +88,7 @@ export const actions = {
                   if (error.type === 'missing') {
                     // Check the section we are in
                     if (section === 'upstream') {
-                      // Upstream providers should have a domain and service key.
+                      // Upstream providers should have a domain and service-type key.
                       const missingKey = field
                       if (missingKey === 'domain') {
                         if (!line.includes('domain')) {
@@ -97,7 +97,7 @@ export const actions = {
                           return i
                         }
                       } else {
-                        if (!line.includes('service')) {
+                        if (!line.includes('service-type')) {
                           error.line = i + 1
                           errorLines.push(i)
                           return i
@@ -106,7 +106,7 @@ export const actions = {
                     }
       
                     if (section === 'org') {
-                      // Orgs should have a domain, url, and doctype key.
+                      // Orgs should have a domain, url, and doc_type key.
                       const missingKey = field
                       if (missingKey === 'domain') {
                         if (!line.includes('domain')) {
@@ -121,7 +121,7 @@ export const actions = {
                           return i
                         }
                       } else {
-                        if (!line.includes('doctype')) {
+                        if (!line.includes('doc_type')) {
                           error.line = i + 1
                           errorLines.push(i)
                           return i

--- a/src/routes/tools/validator/+page.svelte
+++ b/src/routes/tools/validator/+page.svelte
@@ -7,6 +7,8 @@
 	import SyntaxValidatorSuccess from '$lib/components/tools/SyntaxValidatorSuccess.svelte'
 	import SyntaxValidatorError from '$lib/components/tools/SyntaxValidatorError.svelte'
 	import ToolsNav from '$lib/components/ToolsNav.svelte'
+	import Button from '$lib/components/Button.svelte'
+	import Callout from '$lib/components/Callout.svelte'
 	import { onMount } from 'svelte'
 
 	/** @type {{ data: import('./$types').PageData, form: import('./$types').ActionData }} */
@@ -39,6 +41,13 @@
 				<li>Check that the contents of a carbon.txt file is syntactically valid.</li>
 				<li>View the content of the carbon.txt file in a human-readable format.</li>
 			</ul>
+
+			<Callout>
+				<p>
+					This validator performs checks on Carbon.txt files based on the <b>version 0.2 syntax</b>.
+				</p>
+				<div class="w-max mx-auto mt-[2rem]"><Button link="/syntax">Learn more about the syntax</Button></div>
+			</Callout>
 		</div>
 		<SyntaxValidator textInput={form?.text_contents || ''} url={form?.url || url || ''} />
 	</div>


### PR DESCRIPTION
This update adds a page to the website that shows the current and previous carbon.txt syntax specifications. 

- Users can use a select dropdown on the page to change between the different versions.
- A new syntax section is also included in the header.
- A link to the syntax page is included on the builder page.
