### PR TITLE
Update documentation to clarify what a valid domain is

### DIFF
--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -87,7 +87,7 @@
 
 		if (!urlRegex.test(newObject.url)) {
 			error.field = 'org-url'
-			error.message = 'Please enter a valid URL'
+			error.message = 'Please enter a valid URL beginning with "http://" or "https://'
 			return
 		}
 

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -40,7 +40,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'upstream-domain'
-			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http:// or "https://").'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http:// or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).'
 			return
 		}
 
@@ -66,7 +66,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'org-domain'
-			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http://" or "https://").'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http://" or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).'
 			return
 		}
 
@@ -140,7 +140,7 @@
 		<div class="form-group">
 			<span>
 				<label for="domain">Domain</label>
-				<small>The domain of the provider who's services you use. Do not include the protocol (i.e. http:// or https://).</small>
+				<small>The domain of the provider who's services you use. Do not include the protocol (i.e. http:// or https://) or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).</small>
 			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'upstream-domain'}
@@ -197,7 +197,7 @@
 		<div class="form-group">
 			<span>
 				<label for="domain">Domain</label>
-				<small>The domain for which the document applies. Do not include the protocol (i.e. http:// or https://).</small>
+				<small>The domain for which the document applies. Do not include the protocol (i.e. http:// or https://) or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).</small>
 			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'org-domain'}

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -40,7 +40,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'upstream-domain'
-			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. http:// or https://).'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http:// or "https://").'
 			return
 		}
 
@@ -66,7 +66,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'org-domain'
-			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. http:// or https://).'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. "http://" or "https://").'
 			return
 		}
 

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -40,7 +40,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'upstream-domain'
-			error.message = 'Please enter a valid domain'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. http:// or https://).'
 			return
 		}
 
@@ -66,7 +66,7 @@
 		const domainRegex = new RegExp(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/)
 		if (!domainRegex.test(newObject.domain)) {
 			error.field = 'org-domain'
-			error.message = 'Please enter a valid domain'
+			error.message = 'Please enter a valid domain. Do not include the protocol (i.e. http:// or https://).'
 			return
 		}
 

--- a/src/lib/components/tools/BuilderInput.svelte
+++ b/src/lib/components/tools/BuilderInput.svelte
@@ -140,7 +140,7 @@
 		<div class="form-group">
 			<span>
 				<label for="domain">Domain</label>
-				<small>The domain of the provider who's services you use.</small>
+				<small>The domain of the provider who's services you use. Do not include the protocol (i.e. http:// or https://).</small>
 			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'upstream-domain'}
@@ -197,7 +197,7 @@
 		<div class="form-group">
 			<span>
 				<label for="domain">Domain</label>
-				<small>The domain for which the document applies.</small>
+				<small>The domain for which the document applies. Do not include the protocol (i.e. http:// or https://).</small>
 			</span>
 			<input type="text" name="domain" bind:value={newObject.domain} placeholder="example.com" />
 			{#if error.field === 'org-domain'}

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -22,7 +22,6 @@ export const syntaxVersions = [
 						type: '[[array]]',
 						longTitle: 'Providers',
 						description: 'Information linking your organisation to upstream providers used to deliver your services.',
-						type: 'array',
 						properties: [
 							{
 								name: 'domain',

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -64,7 +64,6 @@ providers = [
 						type: '[[array]]',
 						longTitle: 'Credentials',
 						description: 'Links to documents that show your organisations sustainability credentials.',
-						type: 'array',
 						properties: [
 							{
 								name: 'domain',
@@ -87,7 +86,7 @@ providers = [
 								required: false,
 								parent: 'credentials',
 								longTitle: 'URL',
-								description: 'The URL of the document you are linking to.',
+								description: 'The URL of the document you are linking to beginning with "http://" or "https://.',
 								type: 'url'
 							}
 						]

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -29,7 +29,7 @@ export const syntaxVersions = [
 								parent: 'providers',
 								longTitle: 'Domain',
 								description:
-									'The domain of the organisation providing the upstream service. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://").',
+									'The domain of the organisation providing the upstream service. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).',
 								type: 'string'
 							},
 							{
@@ -69,7 +69,8 @@ providers = [
 								required: false,
 								parent: 'credentials',
 								longTitle: 'Domain',
-								description: 'The domain of your organisation. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://").',
+								description:
+									'The domain of your organisation. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).',
 								type: 'string'
 							},
 							{
@@ -146,7 +147,7 @@ credentials = [
 								required: true,
 								parent: 'disclosures',
 								longTitle: 'URL',
-								description: 'The URL of the document you are linking to.',
+								description: 'The URL of the document you are linking to beginning with "http://" or "https://.',
 								type: 'url'
 							},
 							{
@@ -154,7 +155,8 @@ credentials = [
 								required: false,
 								parent: 'disclosures',
 								longTitle: 'Domain',
-								description: 'The domain for which the disclosure applies.',
+								description:
+									'The domain for which the disclosure applies. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).',
 								type: 'string'
 							}
 						]
@@ -186,7 +188,8 @@ disclosures = [
 								required: false,
 								parent: 'services',
 								longTitle: 'Domain',
-								description: 'The domain of the organisation providing the upstream service.',
+								description:
+									'The domain of the organisation providing the upstream service. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://") or any content paths (e.g "/news/", "/about", "news-update-2025" etc.).',
 								type: 'string'
 							},
 							{

--- a/src/lib/utils/syntax.js
+++ b/src/lib/utils/syntax.js
@@ -1,105 +1,106 @@
 import fetchEvidenceTypes from '$lib/utils/evidenceTypes'
 
 export const syntaxVersions = [
-    {
-        name: '0.1',
-        current: false,
-        validFrom: '2021-01-01',
-        validTo: '2025-01-22',
-        language: 'TOML',
-        syntax: [
-            {
-                name: 'upstream',
-                required: true,
-                type: '[table]',
-                longTitle: 'Upstream providers',
-                description: 'Information linking your organisation to upstream providers used to deliver your services.',
-                properties: [
-                    {
-                        name: 'providers',
-                        parent: 'upstream',
-                        required: true,
-                        type: '[[array]]',
-                        longTitle: 'Providers',
-                        description: 'Information linking your organisation to upstream providers used to deliver your services.',
-                        type: 'array',
-                        properties: [
-                            {
-                                name: 'domain',
-                                required: true,
-                                parent: 'providers',
-                                longTitle: 'Domain',
-                                description: 'The domain of the organisation providing the upstream service.',
-                                type: 'string',
-                            },
-                            {
-                                name: 'service',
-                                required: true,
-                                parent: 'providers',
-                                longTitle: 'Service',
-                                description: 'A slug representing the service provided by the upstream provider.',
-                                type: 'string',
-                            }
-                        ]
-                    }
-                ],
-                example: `[upstream]
+	{
+		name: '0.1',
+		current: false,
+		validFrom: '2021-01-01',
+		validTo: '2025-01-22',
+		language: 'TOML',
+		syntax: [
+			{
+				name: 'upstream',
+				required: true,
+				type: '[table]',
+				longTitle: 'Upstream providers',
+				description: 'Information linking your organisation to upstream providers used to deliver your services.',
+				properties: [
+					{
+						name: 'providers',
+						parent: 'upstream',
+						required: true,
+						type: '[[array]]',
+						longTitle: 'Providers',
+						description: 'Information linking your organisation to upstream providers used to deliver your services.',
+						type: 'array',
+						properties: [
+							{
+								name: 'domain',
+								required: true,
+								parent: 'providers',
+								longTitle: 'Domain',
+								description:
+									'The domain of the organisation providing the upstream service. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://").',
+								type: 'string'
+							},
+							{
+								name: 'service',
+								required: true,
+								parent: 'providers',
+								longTitle: 'Service',
+								description: 'A slug representing the service provided by the upstream provider.',
+								type: 'string'
+							}
+						]
+					}
+				],
+				example: `[upstream]
 providers = [
     { domain = "cloud.google.com", service = "shared-hosting" },
     { domain = "aws.amazon.com", service = "cdn" }
 ]`
-            },
-                {
-                    name: 'org',
-                    required: false,
-                    type: '[table]',
-                    longTitle: 'Organisation credentials',
-                    description: 'Links to documents that show your organisations sustainability credentials.',
-                    properties: [
-                        {
-                            name: 'credentials',
-                            parent: 'org',
-                            required: false,
-                            type: '[[array]]',
-                            longTitle: 'Credentials',
-                            description: 'Links to documents that show your organisations sustainability credentials.',
-                            type: 'array',
-                            properties: [
-                                {
-                                    name: 'domain',
-                                    required: false,
-                                    parent: 'credentials',
-                                    longTitle: 'Domain',
-                                    description: 'The domain of your organisation.',
-                                    type: 'string',
-                                },
-                                {
-                                    name: 'doctype',
-                                    required: false,
-                                    parent: 'credentials',
-                                    longTitle: 'Document type',
-                                    description: 'A slugified string representing the type of document you are linking to.  Accepted values are: "webpage", "annual-report", "sustainability-page", "certificate", "other"',
-                                    type: 'string',
-                                },
-                                {
-                                    name: 'url',
-                                    required: false,
-                                    parent: 'credentials',
-                                    longTitle: 'URL',
-                                    description: 'The URL of the document you are linking to.',
-                                    type: 'url',
-                                }
-                            ]
-                        }
-                    ],
-                    example: `[org]
+			},
+			{
+				name: 'org',
+				required: false,
+				type: '[table]',
+				longTitle: 'Organisation credentials',
+				description: 'Links to documents that show your organisations sustainability credentials.',
+				properties: [
+					{
+						name: 'credentials',
+						parent: 'org',
+						required: false,
+						type: '[[array]]',
+						longTitle: 'Credentials',
+						description: 'Links to documents that show your organisations sustainability credentials.',
+						type: 'array',
+						properties: [
+							{
+								name: 'domain',
+								required: false,
+								parent: 'credentials',
+								longTitle: 'Domain',
+								description: 'The domain of your organisation. This can include any subdomains (e.g. "www."), but should not include the protocol (i.e. "http://" or "https://").',
+								type: 'string'
+							},
+							{
+								name: 'doctype',
+								required: false,
+								parent: 'credentials',
+								longTitle: 'Document type',
+								description: 'A slugified string representing the type of document you are linking to.  Accepted values are: "webpage", "annual-report", "sustainability-page", "certificate", "other"',
+								type: 'string'
+							},
+							{
+								name: 'url',
+								required: false,
+								parent: 'credentials',
+								longTitle: 'URL',
+								description: 'The URL of the document you are linking to.',
+								type: 'url'
+							}
+						]
+					}
+				],
+				example: `[org]
 credentials = [
     { domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
     { domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
-]`,
-                },
-            ],
-        example: `[upstream]	
+]`
+			}
+		],
+		example: `[upstream]
 providers = [
     { domain = "cloud.google.com", service = "shared-hosting" },
     { domain = "aws.amazon.com", service = "cdn" }
@@ -110,114 +111,114 @@ credentials = [
     { domain = "mycompany.com", doctype = "webpage", url = "https://mycompany.com/sustainability" },
     { domain = "mycompany.com", doctype = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf" }
 ]`
-    },
-    {
-        name: '0.2',
-        current: true,
-        validFrom: '2025-01-23',
-        validTo: '-',
-        language: 'TOML',
-        syntax: [
-            {
-                name: 'org',
-                required: true,
-                longTitle: 'Organisation disclosures',
-                // description: 'Links to documents that show your organisations sustainability disclosures.',
-                type: '[table]',
-                properties: [
-                    {
-                        name: 'disclosures',
-                        parent: 'org',
-                        required: false,
-                        longTitle: 'disclosures',
-                        description: 'Links to documents that show your organisations sustainability data disclosures.',
-                        type: '[[array]]',
-                        properties: [
-                            {
-                                name: 'doc_type',
-                                required: true,
-                                parent: 'disclosures',
-                                longTitle: 'Document type',
-                                description: 'A slugified string representing the type of document you are linking to. Accepted values are: "web-page", "annual-report", "sustainability-page", "certificate", "csrd-report", "other"',
-                                type: 'string',
-                            },
-                            {
-                                name: 'url',
-                                required: true,
-                                parent: 'disclosures',
-                                longTitle: 'URL',
-                                description: 'The URL of the document you are linking to.',
-                                type: 'url',
-                            },
-                            {
-                                name: 'domain',
-                                required: false,
-                                parent: 'disclosures',
-                                longTitle: 'Domain',
-                                description: 'The domain for which the disclosure applies.',
-                                type: 'string',
-                            },
-                        ]
-                    }
-                ],
-                example: `[org]
+	},
+	{
+		name: '0.2',
+		current: true,
+		validFrom: '2025-01-23',
+		validTo: '-',
+		language: 'TOML',
+		syntax: [
+			{
+				name: 'org',
+				required: true,
+				longTitle: 'Organisation disclosures',
+				// description: 'Links to documents that show your organisations sustainability disclosures.',
+				type: '[table]',
+				properties: [
+					{
+						name: 'disclosures',
+						parent: 'org',
+						required: false,
+						longTitle: 'disclosures',
+						description: 'Links to documents that show your organisations sustainability data disclosures.',
+						type: '[[array]]',
+						properties: [
+							{
+								name: 'doc_type',
+								required: true,
+								parent: 'disclosures',
+								longTitle: 'Document type',
+								description:
+									'A slugified string representing the type of document you are linking to. Accepted values are: "web-page", "annual-report", "sustainability-page", "certificate", "csrd-report", "other"',
+								type: 'string'
+							},
+							{
+								name: 'url',
+								required: true,
+								parent: 'disclosures',
+								longTitle: 'URL',
+								description: 'The URL of the document you are linking to.',
+								type: 'url'
+							},
+							{
+								name: 'domain',
+								required: false,
+								parent: 'disclosures',
+								longTitle: 'Domain',
+								description: 'The domain for which the disclosure applies.',
+								type: 'string'
+							}
+						]
+					}
+				],
+				example: `[org]
 disclosures = [
 	{ doc_type = "web-page", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
 	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
-]`,
-            },
-            {
-                name: 'upstream',
-                required: true,
-                type: '[table]',
-                longTitle: 'Upstream services',
-                // description: 'Information linking your organisation to upstream providers used to deliver your services.',
-                properties: [
-                    {
-                        name: 'services',
-                        parent: 'upstream',
-                        required: false,
-                        longTitle: 'Services',
-                        description: 'Information linking your organisation to upstream providers you use.',
-                        type: '[[array]]',
-                        properties: [
-                            {
-                                name: 'domain',
-                                required: false,
-                                parent: 'services',
-                                longTitle: 'Domain',
-                                description: 'The domain of the organisation providing the upstream service.',
-                                type: 'string',
-                            },
-                            {
-                                name: 'service_type',
-                                required: false,
-                                parent: 'services',
-                                longTitle: 'Service type',
-                                description: 'A slug representing the service provided by the upstream provider.',
-                                type: 'string or ["array of strings"]',
-                            }
-                        ]
-                    }
-                ],
-                example: `[upstream]
+]`
+			},
+			{
+				name: 'upstream',
+				required: true,
+				type: '[table]',
+				longTitle: 'Upstream services',
+				// description: 'Information linking your organisation to upstream providers used to deliver your services.',
+				properties: [
+					{
+						name: 'services',
+						parent: 'upstream',
+						required: false,
+						longTitle: 'Services',
+						description: 'Information linking your organisation to upstream providers you use.',
+						type: '[[array]]',
+						properties: [
+							{
+								name: 'domain',
+								required: false,
+								parent: 'services',
+								longTitle: 'Domain',
+								description: 'The domain of the organisation providing the upstream service.',
+								type: 'string'
+							},
+							{
+								name: 'service_type',
+								required: false,
+								parent: 'services',
+								longTitle: 'Service type',
+								description: 'A slug representing the service provided by the upstream provider.',
+								type: 'string or ["array of strings"]'
+							}
+						]
+					}
+				],
+				example: `[upstream]
 services = [
     { domain = "cloud.google.com", service_type = "shared-hosting" },
     { domain = "aws.amazon.com", service_type = "cdn" }
 ]`
-            },
-                
-            ],
-        example: `[org]
+			}
+		],
+		example: `[org]
 disclosures = [
 	{ doc_type = "web-page", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
 	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" }
 ]
-	
-[upstream]	
+
+[upstream]
 services = [
 	{ domain = "cloud.google.com", service_type = "shared-hosting" },
 	{ domain = "aws.amazon.com", service_type = "cdn" }
 ]`
-    },
+	}
 ]


### PR DESCRIPTION
Fixes #11 

This PR clarifies the expected formats of different fields in carbon.txt files.
Namely, it clarifies the definition of `domain` and `url` fields.

- `domain` fields should be strings that represent a valid website domain. They can include subdomains (e.g. "www") but should not include the protocol (i.e. "http://" or "https://"). Nor should it include any content paths or slugs (e.g "/news/", "/about", "news-update-2025" etc.)
- `url` fields should be strings that represent a valid URL (or URI). They should include the protocol (i.e. "http://" or "https://"), and can also include content paths or slugs (e.g "/news/", "/about", "news-update-2025", "/files/2025-report.pdf" etc.)
