### PR TITLE
Add logs to validator page

### DIFF
--- a/src/lib/components/tools/ValidatorLogs.svelte
+++ b/src/lib/components/tools/ValidatorLogs.svelte
@@ -1,0 +1,36 @@
+<script>
+	let { logs, isError = false } = $props()
+	let open = isError
+</script>
+
+<section class="w-100 mb-4" id="logss">
+	<div class="prose md:w-[80%] mb-4">
+		<h1 class="text-3xl font-bold mb-4">Log trace</h1>
+		<p>Below are the steps performed by the validator.</p>
+	</div>
+
+	<!-- <details {() => isError ? "open" : ""}> -->
+	<details {open}>
+		<summary>View logs</summary>
+		<ol>
+			{#each logs as log}
+				<li>{log}</li>
+			{/each}
+		</ol>
+	</details>
+</section>
+
+<style>
+	ol {
+		font-family: 'Courier New', Courier, monospace;
+		list-style-type: decimal-leading-zero;
+		padding: 0.5rem;
+		border: 1px solid black;
+		background: white;
+		border-radius: 8px;
+	}
+
+	ol > li {
+		margin-inline-start: 2.5rem;
+	}
+</style>

--- a/src/lib/components/tools/ValidatorLogs.svelte
+++ b/src/lib/components/tools/ValidatorLogs.svelte
@@ -1,10 +1,11 @@
 <script>
+	import Heading from '../Heading.svelte'
 	let { logs, open = false } = $props()
 </script>
 
-<section class="w-100 mb-4" id="logss">
+<section class="w-100 mb-8" id="logs">
 	<div class="prose md:w-[80%] mb-4">
-		<h1 class="text-3xl font-bold mb-4">Log trace</h1>
+		<Heading level={2}>Log trace</Heading>
 		<p>Below are the steps performed by the validator.</p>
 	</div>
 

--- a/src/lib/components/tools/ValidatorLogs.svelte
+++ b/src/lib/components/tools/ValidatorLogs.svelte
@@ -1,6 +1,5 @@
 <script>
-	let { logs, isError = false } = $props()
-	let open = isError
+	let { logs, open = false } = $props()
 </script>
 
 <section class="w-100 mb-4" id="logss">
@@ -21,6 +20,10 @@
 </section>
 
 <style>
+	section {
+		overflow: hidden;
+	}
+
 	ol {
 		font-family: 'Courier New', Courier, monospace;
 		list-style-type: decimal-leading-zero;
@@ -28,9 +31,11 @@
 		border: 1px solid black;
 		background: white;
 		border-radius: 8px;
+		overflow: auto;
 	}
 
 	ol > li {
 		margin-inline-start: 2.5rem;
+		margin-block: 0.5rem;
 	}
 </style>

--- a/src/routes/tools/validator/+page.svelte
+++ b/src/routes/tools/validator/+page.svelte
@@ -54,7 +54,7 @@
 
 {#if form?.response.success}
 	<SyntaxValidatorSuccess text_contents={form?.text_contents} {form} />
-	<ValidatorLogs logs={form?.response.logs} open={true} />
+	<ValidatorLogs logs={form?.response.logs} open={false} />
 	<section class="w-100">
 		<div class="prose md:w-[80%] my-4">
 			<h2 class="text-3xl font-bold mb-4">Think something's wrong?</h2>

--- a/src/routes/tools/validator/+page.svelte
+++ b/src/routes/tools/validator/+page.svelte
@@ -7,6 +7,7 @@
 	import SyntaxValidatorSuccess from '$lib/components/tools/SyntaxValidatorSuccess.svelte'
 	import SyntaxValidatorError from '$lib/components/tools/SyntaxValidatorError.svelte'
 	import ToolsNav from '$lib/components/ToolsNav.svelte'
+	import ValidatorLogs from '$lib/components/tools/ValidatorLogs.svelte'
 	import Button from '$lib/components/Button.svelte'
 	import Callout from '$lib/components/Callout.svelte'
 	import { onMount } from 'svelte'
@@ -53,6 +54,7 @@
 
 {#if form?.response.success}
 	<SyntaxValidatorSuccess text_contents={form?.text_contents} {form} />
+	<ValidatorLogs logs={form?.response.logs} open={true} />
 	<section class="w-100">
 		<div class="prose md:w-[80%] my-4">
 			<h2 class="text-3xl font-bold mb-4">Think something's wrong?</h2>
@@ -64,6 +66,7 @@
 	</section>
 {:else if form?.response.errors}
 	<SyntaxValidatorError text_contents={form?.text_contents} errors={form?.response.errors} errorLines={form?.response.errorLines} />
+	<ValidatorLogs logs={form?.response.logs} open={true} />
 	<section class="w-100">
 		<div class="prose md:w-[80%] my-4">
 			<h2 class="text-3xl font-bold mb-4">Think something's wrong?</h2>
@@ -81,6 +84,7 @@
 			<p>For help creating a carbon.txt file, please use our <a href="/tools/builder">Builder</a>.</p>
 		</div>
 	</section>
+	<ValidatorLogs logs={form?.response.logs} open={true} />
 	<section class="w-100">
 		<div class="prose md:w-[80%] mb-4">
 			<h2 class="text-3xl font-bold m-4">Think something's wrong?</h2>


### PR DESCRIPTION
This PR adds a section to the validator page that will display the log trace of each lookup. The aim is to provide more information about the steps take in any given check.