### PR TITLE
Consistently use spaces for indentation in builder output

### DIFF
--- a/src/routes/tools/builder/+page.svelte
+++ b/src/routes/tools/builder/+page.svelte
@@ -40,10 +40,10 @@
 last_updated="${todaysDate}"
 
 [org]
-disclosures = [${$builderOrg.length > 0 ? '\n\t' + mapOrg() + '\n' : ' '}]
+disclosures = [${$builderOrg.length > 0 ? '\n    ' + mapOrg() + '\n' : ' '}]
 
 [upstream]
-services = [${$builderUpstream.length > 0 ? '\n\t' + mapUpstream() + '\n' : ' '}]`
+services = [${$builderUpstream.length > 0 ? '\n    ' + mapUpstream() + '\n' : ' '}]`
 
 	const resetBuilder = () => {
 		builderUpstream.set([])


### PR DESCRIPTION
I noticed the builder was creating files with mixed indentation in my browser, where tabs are set to display as 8 spaces. That shouldn’t be a problem for any TOML parser out there, but felt worth fixing anyway, so the files look a bit better.

I chose to switch the tab formatting to spaces but it’d equally be correct to switch space formatting to tabs alternatively. No opinions there.

---

If this doesn’t look quite right feel free to take over the PR or close!