### PR TITLE
Provide gwf api key to carbon.txt validator API

### DIFF
--- a/src/lib/components/tools/SyntaxValidator.svelte
+++ b/src/lib/components/tools/SyntaxValidator.svelte
@@ -45,6 +45,7 @@
 		}
 	}}
 >
+  <input type="hidden" name="csrf_token" value={data.csrfToken} />
 	<label class="flex flex-col gap-1" for="domain"
 		>Website domain:
 		<small class="text-xs mb-3">Enter a website domain to check if it has a valid carbon.txt file.</small>

--- a/src/routes/tools/validator/+page.js
+++ b/src/routes/tools/validator/+page.js
@@ -1,6 +1,7 @@
 /** @type {import('./$types').PageLoad} */
-export async function load({ url }) {
+export async function load({ url, data }) {
 	return {
-		url
+		url,
+    ...data
 	}
 }

--- a/src/routes/tools/validator/+page.server.js
+++ b/src/routes/tools/validator/+page.server.js
@@ -1,7 +1,9 @@
 import { load } from 'js-toml'
 import * as publicEnv from '$env/static/public'
+import * as privateEnv from '$env/static/private'
 
 const apiBase = publicEnv['PUBLIC_API_BASE_URL'] || 'https://carbon-txt-api.greenweb.org'
+const apiKey = privateEnv["GWF_API_KEY"];
 
 /** @satisfies {import('./$types').Actions} */
 export const actions = {
@@ -31,6 +33,9 @@ export const actions = {
 
 		const response = await fetch(apiRoute, {
 			method: 'POST',
+      headers: {
+        "X-Api-Key": apiKey,
+      },
 			body: bodyData
 		})
 

--- a/src/routes/tools/validator/+page.server.js
+++ b/src/routes/tools/validator/+page.server.js
@@ -1,4 +1,4 @@
-import { load } from 'js-toml'
+import { load as loadToml } from 'js-toml'
 import { fail } from '@sveltejs/kit';
 import * as publicEnv from '$env/static/public'
 import * as privateEnv from '$env/static/private'
@@ -56,7 +56,7 @@ export const actions = {
 				const lines = text_contents.split('\n')
 				let parsedToml = {}
 				try {
-					parsedToml = await load(text_contents)
+					parsedToml = await loadToml(text_contents)
 				} catch {
 					return {
 						text_contents,

--- a/src/routes/tools/validator/+page.server.js
+++ b/src/routes/tools/validator/+page.server.js
@@ -1,14 +1,24 @@
 import { load } from 'js-toml'
+import { fail } from '@sveltejs/kit';
 import * as publicEnv from '$env/static/public'
 import * as privateEnv from '$env/static/private'
 
 const apiBase = publicEnv['PUBLIC_API_BASE_URL'] || 'https://carbon-txt-api.greenweb.org'
 const apiKey = privateEnv["GWF_API_KEY"];
 
+export function load({ cookies }) {
+  const token = crypto.randomUUID();
+  cookies.set('csrf', token, { httpOnly: false, sameSite: 'strict', path: "/" });
+  return { csrfToken: token };
+}
+
 /** @satisfies {import('./$types').Actions} */
 export const actions = {
-	validate: async ({ request }) => {
+	validate: async ({ request, cookies }) => {
 		const data = await request.formData()
+    if (data.get('csrf_token') !== cookies.get('csrf')) {
+      return fail(403, { response: { error: 'Invalid CSRF token' }});
+    }
 		const text_contents = data.get('carbon-txt-validator')
 		const url = data.get('url')
 		let domain = data.get('domain')

--- a/src/routes/tools/validator/+page.svelte
+++ b/src/routes/tools/validator/+page.svelte
@@ -12,7 +12,6 @@
 
 	/** @type {{ data: import('./$types').PageData, form: import('./$types').ActionData }} */
 	let { data, form } = $props()
-
 	let url = ''
 	let domain = ''
 	let searchParams = new URLSearchParams(data.url.search)


### PR DESCRIPTION
Reads the `GWF_API_KEY` environment variable (on the server side) and uses it to authenticate to the GWF carbon txt validator api, and use a random session secret passed with the request to protect against request forgery - this stops people using the svelte server side action to get around the need for an API key.